### PR TITLE
fix: Update Docker images to use latest tags and bump project version to 1.2.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -480,7 +480,7 @@ services:
   # 📊 USERS-API
   # ======================
   users-api:
-    image: santos/users-api:v1.0.0
+    image: kleilsonsantos/users-api:latest
     container_name: infra-default-users-api
     restart: always
     ports:
@@ -508,7 +508,7 @@ services:
   # 📊 WEBHOOK LISTENER
   # ======================
   webhook-listener:
-    image: santos/webhook-alerts-rabbitmq:v1.0.1
+    image: kleilsonsantos/webhook-alerts-rabbitmq:latest
     container_name: infra-default-webhook-listener
     restart: always
     ports:
@@ -545,7 +545,7 @@ services:
       - infra-default-shared-net
 
   eureka-server:
-    image: santos/eureka-server:latest
+    image: kleilsonsantos/eureka-server:latest
     container_name: infra-default-eureka-server
     ports:
       - "8761:8761"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infra-devtools",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Infraestrutura padrão para desenvolvimento com Docker, Prometheus, Grafana e outras ferramentas essenciais.",
   "keywords": [
     "docker",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectName=Infra Dev Tools
 sonar.projectKey=infra-devtools
-sonar.projectVersion=1.0.9
+sonar.projectVersion=1.2.6
 
 sonar.host.url=${SONAR_HOST_URL}
 sonar.token=${SONAR_TOKEN_INFRA_DEVTOOLS}


### PR DESCRIPTION
🛠️ Correção

Este pull request atualiza as referências de imagens Docker para utilizar a tag latest e ajusta a versão do projeto para 1.2.6.

🐳 Atualizações de Imagens Docker

As imagens personalizadas utilizadas no docker-compose.yml foram atualizadas para usar a tag latest, garantindo que sempre seja utilizada a versão mais recente durante o pull.

📦 Gerenciamento de Versão

Atualização do package.json e package-lock.json para refletir a nova versão do projeto: 1.2.6.

🧰 Alterações Realizadas

✅ Ajuste das imagens Docker para :latest no docker-compose.yml.
✅ Incremento da versão do projeto para 1.2.6.

🎯 Objetivo

O objetivo desta entrega é garantir que a infraestrutura esteja sempre atualizada com as versões mais recentes das imagens Docker utilizadas no projeto, além de manter o controle de versão sincronizado. Isso melhora a previsibilidade e facilita o deploy em múltiplos ambientes. 🚀